### PR TITLE
fix(clang): mixing declarations and code

### DIFF
--- a/drill_mod.c
+++ b/drill_mod.c
@@ -27,6 +27,9 @@ static int drill_act_exec(long act,
 {
 	int ret = 0;
 	unsigned long n = 0;
+	unsigned long val = 0;
+	unsigned long offset = 0;
+	unsigned long *data_addr = NULL;
 
 	if (!arg1_str) {
 		pr_err("drill: item number is missing\n");
@@ -67,10 +70,6 @@ static int drill_act_exec(long act,
 		break;
 
 	case DRILL_ACT_SAVE_VAL:
-		unsigned long val = 0;
-		unsigned long offset = 0;
-		unsigned long *data_addr = NULL;
-
 		if (!arg2_str) {
 			pr_err("drill: save_val: missing value\n");
 			return -EINVAL;


### PR DESCRIPTION
hello, @a13xp0p0v 

i recently tried to integrate drill into COS kernel

`clang` a bit mad at some variable decalrations:

```
d@c553020e9dfc:/src/drill/kernel-hack-drill$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
d@c553020e9dfc:/src/drill/kernel-hack-drill$ KPATH=../. make LLVM=1 -j16
gcc drill_test.c -Wall -static -o drill_test
gcc drill_uaf_callback.c -Wall -static -o drill_uaf_callback
gcc drill_uaf_callback_rop_smep.c  -Wall -static -o drill_uaf_callback_rop_smep
gcc drill_uaf_w_msg_msg.c -Wall -static -o drill_uaf_w_msg_msg
gcc drill_uaf_w_pipe_buffer.c -Wall -static -o drill_uaf_w_pipe_buffer
gcc drill_uaf_w_pte.c -Wall -static -o drill_uaf_w_pte
gcc drill_uaf_w_pud.c -Wall -static -o drill_uaf_w_pud
make -C ../. M=/src/drill/kernel-hack-drill modules
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[1]: Entering directory '/src/drill'
  CC [M]  /src/drill/kernel-hack-drill/drill_mod.o
/src/drill/kernel-hack-drill/drill_mod.c:70:3: error: expected expression
                unsigned long val = 0;
                ^
/src/drill/kernel-hack-drill/drill_mod.c:84:32: error: use of undeclared identifier 'val'
                ret = kstrtoul(arg2_str, 0, &val);
                                             ^
/src/drill/kernel-hack-drill/drill_mod.c:97:42: error: use of undeclared identifier 'val'
                                sizeof(struct drill_item_t) - sizeof(val)) {
                                                                     ^
/src/drill/kernel-hack-drill/drill_mod.c:104:6: error: use of undeclared identifier 'val'
                                        val, n, (unsigned long)drill.items[n],
                                        ^
/src/drill/kernel-hack-drill/drill_mod.c:106:16: error: use of undeclared identifier 'val'
                *data_addr = val;  /* No check, BAD BAD BAD */
                             ^
/src/drill/kernel-hack-drill/drill_mod.c:71:17: warning: mixing declarations and code is a C99 extension [-Wdeclaration-after-statement]
                unsigned long offset = 0;
                              ^
1 warning and 5 errors generated.
make[2]: *** [scripts/Makefile.build:280: /src/drill/kernel-hack-drill/drill_mod.o] Error 1
make[1]: *** [Makefile:1822: /src/drill/kernel-hack-drill] Error 2
make[1]: Leaving directory '/src/drill'
make: *** [Makefile:16: all] Error 2
d@c553020e9dfc:/src/drill/kernel-hack-drill$
```

i have beautiful fix for that:

```
d@c553020e9dfc:/src/drill/kernel-hack-drill$ git diff HEAD~1
diff --git a/drill_mod.c b/drill_mod.c
index da17f7b..084b64b 100644
--- a/drill_mod.c
+++ b/drill_mod.c
@@ -27,6 +27,9 @@ static int drill_act_exec(long act,
 {
        int ret = 0;
        unsigned long n = 0;
+       unsigned long val = 0;
+       unsigned long offset = 0;
+       unsigned long *data_addr = NULL;

        if (!arg1_str) {
                pr_err("drill: item number is missing\n");
@@ -67,10 +70,6 @@ static int drill_act_exec(long act,
                break;

        case DRILL_ACT_SAVE_VAL:
-               unsigned long val = 0;
-               unsigned long offset = 0;
-               unsigned long *data_addr = NULL;
-
                if (!arg2_str) {
                        pr_err("drill: save_val: missing value\n");
                        return -EINVAL;
d@c553020e9dfc:/src/drill/kernel-hack-drill$ KPATH=../. make LLVM=1
gcc drill_test.c -Wall -static -o drill_test
gcc drill_uaf_callback.c -Wall -static -o drill_uaf_callback
gcc drill_uaf_callback_rop_smep.c  -Wall -static -o drill_uaf_callback_rop_smep
gcc drill_uaf_w_msg_msg.c -Wall -static -o drill_uaf_w_msg_msg
gcc drill_uaf_w_pipe_buffer.c -Wall -static -o drill_uaf_w_pipe_buffer
gcc drill_uaf_w_pte.c -Wall -static -o drill_uaf_w_pte
gcc drill_uaf_w_pud.c -Wall -static -o drill_uaf_w_pud
make -C ../. M=/src/drill/kernel-hack-drill modules
make[1]: Entering directory '/src/drill'
  CC [M]  /src/drill/kernel-hack-drill/drill_mod.o
  MODPOST /src/drill/kernel-hack-drill/Module.symvers
  CC [M]  /src/drill/kernel-hack-drill/drill_mod.mod.o
  LD [M]  /src/drill/kernel-hack-drill/drill_mod.ko
make[1]: Leaving directory '/src/drill'
d@c553020e9dfc:/src/drill/kernel-hack-drill$
```

